### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,47 +5,47 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-DallasTemperature		KEYWORD1
-OneWire					KEYWORD1
-AlarmHandler			KEYWORD1
-DeviceAddress			KEYWORD1
+DallasTemperature	KEYWORD1
+OneWire	KEYWORD1
+AlarmHandler	KEYWORD1
+DeviceAddress	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setResolution			KEYWORD2
-getResolution			KEYWORD2
-getTempC				KEYWORD2
-toFahrenheit			KEYWORD2
-getTempF				KEYWORD2
-getTempCByIndex 		KEYWORD2
-getTempFByIndex			KEYWORD2
+setResolution	KEYWORD2
+getResolution	KEYWORD2
+getTempC	KEYWORD2
+toFahrenheit	KEYWORD2
+getTempF	KEYWORD2
+getTempCByIndex	KEYWORD2
+getTempFByIndex	KEYWORD2
 setWaitForConversion	KEYWORD2
 getWaitForConversion	KEYWORD2
-requestTemperatures		KEYWORD2
+requestTemperatures	KEYWORD2
 requestTemperaturesByAddress	KEYWORD2
 requestTemperaturesByIndex	KEYWORD2
-isParasitePowerMode		KEYWORD2
-begin					KEYWORD2
-getDeviceCount			KEYWORD2
-getAddress				KEYWORD2
-validAddress			KEYWORD2
-isConnected				KEYWORD2
-readScratchPad			KEYWORD2
-writeScratchPad			KEYWORD2
-readPowerSupply			KEYWORD2
-setHighAlarmTemp		KEYWORD2
-setLowAlarmTemp			KEYWORD2
-getHighAlarmTemp		KEYWORD2
-getLowAlarmTemp			KEYWORD2
-resetAlarmSearch		KEYWORD2
-alarmSearch				KEYWORD2
-hasAlarm				KEYWORD2
-toCelsius				KEYWORD2
-processAlarmss			KEYWORD2
-setAlarmHandlers		KEYWORD2
-defaultAlarmHandler		KEYWORD2
+isParasitePowerMode	KEYWORD2
+begin	KEYWORD2
+getDeviceCount	KEYWORD2
+getAddress	KEYWORD2
+validAddress	KEYWORD2
+isConnected	KEYWORD2
+readScratchPad	KEYWORD2
+writeScratchPad	KEYWORD2
+readPowerSupply	KEYWORD2
+setHighAlarmTemp	KEYWORD2
+setLowAlarmTemp	KEYWORD2
+getHighAlarmTemp	KEYWORD2
+getLowAlarmTemp	KEYWORD2
+resetAlarmSearch	KEYWORD2
+alarmSearch	KEYWORD2
+hasAlarm	KEYWORD2
+toCelsius	KEYWORD2
+processAlarmss	KEYWORD2
+setAlarmHandlers	KEYWORD2
+defaultAlarmHandler	KEYWORD2
 calculateTemperature	KEYWORD2
 
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords